### PR TITLE
F2F-358:Added new BE name to workflow file secrets

### DIFF
--- a/.github/workflows/post-merge-package-to-build.yml
+++ b/.github/workflows/post-merge-package-to-build.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Assume temporary AWS role
         uses: aws-actions/configure-aws-credentials@v1-node16
         with:
-          role-to-assume: ${{ secrets.BUILD_CRI_V1_GH_ACTIONS_ROLE_ARN }}
+          role-to-assume: ${{ secrets.BUILD_CRI_CIC_GH_ACTIONS_ROLE_ARN }}
           aws-region: ${{ env.AWS_REGION }}
 
       - name: SAM Validate
@@ -47,7 +47,7 @@ jobs:
       - name: Deploy SAM app
         uses: alphagov/di-devplatform-upload-action@v3
         with:
-            artifact-bucket-name: ${{ secrets.BUILD_CRI_V1_ARTIFACT_SOURCE_BUCKET_NAME }}
-            signing-profile-name: ${{ secrets.BUILD_SIGNING_PROFILE_NAME }}
+            artifact-bucket-name: ${{ secrets.BUILD_CRI_CIC_ARTIFACT_SOURCE_BUCKET_NAME }}
+            signing-profile-name: ${{ secrets.BUILD_CRI_CIC_SIGNING_PROFILE_NAME }}
             working-directory: deploy
             template-file: template.yaml

--- a/.github/workflows/post-merge-package-to-dev.yml
+++ b/.github/workflows/post-merge-package-to-dev.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Assume temporary AWS role
         uses: aws-actions/configure-aws-credentials@v1-node16
         with:
-          role-to-assume: ${{ secrets.DEV_CRI_V1_GH_ACTIONS_ROLE_ARN }}
+          role-to-assume: ${{ secrets.DEV_CRI_CIC_GH_ACTIONS_ROLE_ARN }}
           aws-region: ${{ env.AWS_REGION }}
 
       - name: SAM Validate
@@ -47,7 +47,7 @@ jobs:
       - name: Deploy SAM app
         uses: alphagov/di-devplatform-upload-action@v3
         with:
-            artifact-bucket-name: ${{ secrets.DEV_CRI_V1_ARTIFACT_SOURCE_BUCKET_NAME }}
-            signing-profile-name: ${{ secrets.DEV_SIGNING_PROFILE_NAME }}
+            artifact-bucket-name: ${{ secrets.DEV_CRI_CIC_ARTIFACT_SOURCE_BUCKET_NAME }}
+            signing-profile-name: ${{ secrets.DEV_CRI_CIC_SIGNING_PROFILE_NAME }}
             working-directory: deploy
             template-file: template.yaml

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -89,7 +89,7 @@ jobs:
       - name: Assume temporary AWS role
         uses: aws-actions/configure-aws-credentials@v1-node16
         with:
-          role-to-assume: ${{ secrets.GH_VALIDATE_ROLE_ARN }}
+          role-to-assume: ${{ secrets.CRI_CIC_GH_VALIDATE_ROLE_ARN }}
           aws-region: ${{ env.AWS_REGION }}
 
       - name: Cache SAM builds


### PR DESCRIPTION
Added new github secrets to both build and dev workflows as the BE is being renamed in line with our new pipelines (and away from "V1" convention)

### What changed

BUILD_CRI_CIC_GH_ACTIONS_ROLE_ARN

BUILD_CRI_CIC_ARTIFACT_SOURCE_BUCKET_NAME

BUILD_CRI_CIC_SIGNING_PROFILE_NAME

DEV_CRI_CIC_GH_ACTIONS_ROLE_ARN

DEV_CRI_CIC_ARTIFACT_SOURCE_BUCKET_NAME

DEV_CRI_CIC_SIGNING_PROFILE_NAME

The values of these secrets were also updated from the outputs of the new pipeline.

- [F2F-358](https://govukverify.atlassian.net/browse/F2F-358)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->
- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks

[F2F-358]: https://govukverify.atlassian.net/browse/F2F-358?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ