### PR TITLE
F2F-373: Removed common cri environment

### DIFF
--- a/.github/workflows/pull-request-Dynamo.yml
+++ b/.github/workflows/pull-request-Dynamo.yml
@@ -26,7 +26,6 @@ jobs:
   run-code-check:
     name: Code Checks
     runs-on: ubuntu-latest
-    environment: di-ipv-cri-dev
     defaults:
       run:
         shell: bash

--- a/.github/workflows/pull-request-KMS.yml
+++ b/.github/workflows/pull-request-KMS.yml
@@ -26,7 +26,6 @@ jobs:
   run-code-check:
     name: Code Checks
     runs-on: ubuntu-latest
-    environment: di-ipv-cri-dev
     defaults:
       run:
         shell: bash

--- a/.github/workflows/pull-request-WAF.yml
+++ b/.github/workflows/pull-request-WAF.yml
@@ -26,7 +26,6 @@ jobs:
   run-code-check:
     name: Code Checks
     runs-on: ubuntu-latest
-    environment: di-ipv-cri-dev
     defaults:
       run:
         shell: bash

--- a/.github/workflows/pull-request-ipv-stub.yml
+++ b/.github/workflows/pull-request-ipv-stub.yml
@@ -26,7 +26,6 @@ jobs:
   run-code-check:
     name: Code Checks
     runs-on: ubuntu-latest
-    environment: di-ipv-cri-dev
     defaults:
       run:
         shell: bash

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -28,7 +28,6 @@ jobs:
   run-code-check:
     name: Code Checks
     runs-on: ubuntu-latest
-    environment: di-ipv-cri-dev
     defaults:
       run:
         shell: bash


### PR DESCRIPTION
### What changed

Removed reference to environment: di-ipv-cri-dev in order to allow us to delete common infrastructure from out AWS accounts and not have them redeployed. 

### Why did it change

So that we can remove common infrastructure.

### Issue tracking

- [F2F-373](https://govukverify.atlassian.net/browse/F2F-373)


[F2F-373]: https://govukverify.atlassian.net/browse/F2F-373?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ