### PR TITLE
F2F-134: Added test workflow file to push test container to build test ECR

### DIFF
--- a/.github/workflows/post-merge-push-test-container.yml
+++ b/.github/workflows/post-merge-push-test-container.yml
@@ -1,0 +1,58 @@
+name: Deploy Test Container to Build ECR
+on:
+  # Triggers the workflow on push or pull request events but only for the "main" branch
+  push:
+    branches:
+      - main
+    paths-ignore:
+      - 'infra-l2-dynamo/**'
+      - 'infra-l2-kms/**'
+      - 'infra-l2-waf/**'
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+permissions:
+  id-token: write
+  contents: read
+
+env: # Only adding the variables in that are required for 
+  AWS_REGION: eu-west-2
+
+jobs:
+  deploy-test-container-to-build-ecr:
+    name: Validate & Deploy Test Container to Build Envrionment ECR
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./deploy/
+    steps:
+      - name: Assume temporary AWS role
+        uses: aws-actions/configure-aws-credentials@v1-node16
+        with:
+          role-to-assume: ${{ secrets.BUILD_CRI_CIC_GH_ACTIONS_ROLE_ARN }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      # ... Build and validate SAM application ...
+
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v1
+
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@main
+        with:
+          cosign-release: 'v1.9.0'
+
+      - name: Build, tag, and push testing image to Amazon ECR
+        env:
+          BUILD_CONTAINER_SIGN_KMS_KEY: ${{ secrets.BUILD_CONTAINER_SIGN_KMS_KEY }}
+          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          BUILD_ECR_REPOSITORY: ${{ secrets.BUILD_ECR_REPOSITORY }}
+          IMAGE_TAG: latest
+        run: |
+          docker build -t $ECR_REGISTRY/$BUILD_ECR_REPOSITORY:$IMAGE_TAG .
+          docker push $ECR_REGISTRY/$BUILD_ECR_REPOSITORY:$IMAGE_TAG
+          cosign sign --key awskms:///${BUILD_CONTAINER_SIGN_KMS_KEY} $ECR_REGISTRY/$BUILD_ECR_REPOSITORY:$IMAGE_TAG
+
+      # ... Push build artefacts to S3 ...

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -4,10 +4,11 @@ set -eu
 
 declare status_code
 # shellcheck disable=SC2154
-status_code="$(curl --silent --output /dev/null --write-out '%{http_code}' "$CFN_HelloWorldApi")"
+# status_code="$(curl --silent --output /dev/null --write-out '%{http_code}' "$CFN_HelloWorldApi")"
+status_code="$(curl --silent --output /dev/null --write-out '%{http_code}' "https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200")"
 
 if [[ $status_code != "200" ]]; then
-  cat <<EOF > "$TEST_REPORT_DIR/result.json"
+  cat <<EOF > "$TEST_REPORT_ABSOLUTE_DIR/result.json"
 [
   {
     "uri": "test.sh",
@@ -39,7 +40,7 @@ if [[ $status_code != "200" ]]; then
 EOF
 exit 1
 else
-  cat <<EOF > "$TEST_REPORT_DIR/result.json"
+  cat <<EOF > "$TEST_REPORT_ABSOLUTE_DIR/result.json"
 [
   {
     "uri": "test.sh",


### PR DESCRIPTION
### What changed

- Made some adjustments to the run-tests.sh script
- Added a workflow file to push test container to test ECR in build
- Added BUILD_CONTAINER_SIGN_KMS_KEY, and BUILD_ECR_REPOSITORY secrets

- [F2F-134](https://govukverify.atlassian.net/browse/F2F-134)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO NOT include new environment variables or secrets -->
- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

