### PR TITLE
F2F-100: Add Sonar scan to ipv-cri-cic-api

### DIFF
--- a/.github/workflows/pull-request-sonar.yml
+++ b/.github/workflows/pull-request-sonar.yml
@@ -1,16 +1,16 @@
-name: Sonar Analysis on Merge
+name: Pull Request CI - Sonar
 on:
   workflow_dispatch:
-  # Triggers the workflow on push or pull request events but only for the "main" branch
   push:
     branches:
       - main
   pull_request:
-    types: [opened, synchronize, reopened]
+    types:
+      - opened
+      - reopened
+      - ready_for_review
+      - synchronize
 
-permissions:
-  id-token: write
-  contents: read
 jobs:
   run-code-analysis:
     runs-on: ubuntu-latest
@@ -28,9 +28,9 @@ jobs:
         with:
           node-version: 18
       - name: Install dependencies
-        run: yarn
+        run: npm install
       - name: Test and coverage
-        run: npm run test:unit
+        run: npm run test:unit -- --coverage
       - name: Run Infra checks
         run: npm run test:infra
       - name: "Run SonarCloud Scan"
@@ -38,4 +38,4 @@ jobs:
         uses: SonarSource/sonarcloud-github-action@master
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} 
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/infra-l2-dynamo/jest.config.ts
+++ b/infra-l2-dynamo/jest.config.ts
@@ -17,7 +17,8 @@ export default {
     'default',
     ['jest-junit', { outputDirectory: 'results', outputName: 'report.xml' }]
   ],
-  collectCoverage: false,
+  collectCoverage: true,
+  coverageDirectory: "coverage",
   coverageProvider: 'v8',
   testMatch: ['**/*.test.ts'],
   testEnvironment: 'node'

--- a/infra-l2-kms/jest.config.ts
+++ b/infra-l2-kms/jest.config.ts
@@ -17,7 +17,8 @@ export default {
     'default',
     ['jest-junit', { outputDirectory: 'results', outputName: 'report.xml' }]
   ],
-  collectCoverage: false,
+  collectCoverage: true,
+  coverageDirectory: "coverage",
   coverageProvider: 'v8',
   testMatch: ['**/*.test.ts'],
   testEnvironment: 'node'

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -7,10 +7,12 @@ sonar.organization=alphagov
 
 # Path is relative to the sonar-project.properties file. Replace "\" by "/" on Windows.
 sonar.sources=src/
-sonar.exclusions=**/*.test.js
-Dsonar.ts.coverage.lcovReportPath=lcov.info
+sonar.exclusions=tests/**/*.*,jest.config.ts,src/jest.setup.ts
 sonar.tests=src/
-sonar.test.inclusions=**/*.test.js
+sonar.test.inclusions=**/*.test.ts
+
+sonar.javascript.lcov.reportPaths=src/coverage/lcov.info
 
 # Encoding of the source code. Default is default system encoding
-#sonar.sourceEncoding=UTF-8
+sonar.sourceEncoding=UTF-8
+

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -15,4 +15,3 @@ sonar.javascript.lcov.reportPaths=src/coverage/lcov.info
 
 # Encoding of the source code. Default is default system encoding
 sonar.sourceEncoding=UTF-8
-

--- a/src/package.json
+++ b/src/package.json
@@ -23,7 +23,7 @@
         "node-jose": "^2.1.1"
     },
     "scripts": {
-        "unit": "./node_modules/.bin/jest --testPathPattern=tests/unit",
+        "unit": "./node_modules/.bin/jest --testPathPattern=tests/unit  --coverage",
         "test:unit": "npm run compile && npm run unit",
         "lint:fix": "eslint --fix --output-file ./reports/eslint/report.html --format html -c .eslintrc.js --ext .ts .",
         "compile": "./node_modules/.bin/tsc",


### PR DESCRIPTION
Implement sonar scan properties and workflow to run sonar scan on the di-ipv-cri-cic-api.
This includes the scan files, exclusions and code coverage.
Also modified the jest config to allow coverage

- [F2F-100](https://govukverify.atlassian.net/browse/F2F-100)


[F2F-100]: https://govukverify.atlassian.net/browse/F2F-100?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ