### PR TITLE
F2F-586 Externalised powertools log level in template

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,16 +85,29 @@ Run tests against a CloudFormation stack deployed into AWS: `STACK_NAME=cic-back
 
 This file contains an example of the environment variables that this project requires. To use it, copy the file to `.env` and replace the values with your actual sensitive information.
 To copy the file, run the following command in your terminal:
-```console
+
+```shell
 cp .env.example .env
 ```
+
 Then, open the `.env` file and replace ALL the values with your actual sensitive information.
 Note: The `.env` file should not be committed to the repository, as it contains sensitive information.
+
+## Stack deployment in DEV
+
+To deploy an individual stack in the DEV account from a local branch with full DEBUG logging in the lambdas:
+
+```shell
+cd ./deploy
+sam build --parallel
+sam deploy --resolve-s3 --stack-name "YOUR_STACK_NAME" --confirm-changeset --config-env dev --parameter-overrides \
+  "CodeSigningConfigArn=\"none\" Environment=\"dev\" PermissionsBoundary=\"none\" SecretPrefix=\"none\" VpcStackName=\"vpc-cri\" CommonStackName=\"common-cri-api\" L2DynamoStackName=\"infra-l2-dynamo\" L2KMSStackName=\"infra-l2-kms\" PowertoolsLogLevel=\"DEBUG\""
+```
 
 # Generating JWKS
 
 The public JWKS is not generated automatically when deploying a stack. In order to run the E2E tests, or to successfully call the ./wellknown/jwks endpoint, the key needs to be generated. It can be done as follows:
 
-```bash
+```shell
 aws lambda invoke --function-name JsonWebKeys-<STACK-NAME> response.json
 ```

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -38,6 +38,10 @@ Parameters:
     Type: String
     Default: "cic-cri-kms"
     Description: The name of the L2 DynamoDB stack deployed.
+  PowertoolsLogLevel:
+    Type: String
+    Default: "INFO"
+    Description: Lambda Powertools-for-Typescript Log Level
 
 Mappings:
   EnvironmentConfiguration: # This is where you store per-environment settings.
@@ -165,7 +169,7 @@ Globals:
       Variables:
         # These should always be alphabetically organised.
         AWS_STACK_NAME: !Sub ${AWS::StackName} # The AWS Stack Name, as passed into the template.
-        POWERTOOLS_LOG_LEVEL: INFO # The LogLevel for the AWS PowerTools LogHelper
+        POWERTOOLS_LOG_LEVEL: !Ref PowertoolsLogLevel # The LogLevel for the AWS PowerTools LogHelper
         POWERTOOLS_METRICS_NAMESPACE: CIC-CRI # The Metric Namespace for the AWS PowerTools MetricHelper
         ISSUER: !FindInMap [EnvironmentVariables, !Ref Environment, ISSUER]
         REGION: !Sub "${AWS::Region}"


### PR DESCRIPTION
## Proposed changes

### What changed

Externalised log level in SAM/CFN template as a parameter with INFO as the default.

### Why did it change

Ease of deploying stacks in DEV with DEBUG log level setting

### Issue tracking

- [F2F-586](https://govukverify.atlassian.net/browse/F2F-586)

## Checklists

### Environment variables or secrets

- [x] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks

[F2F-586]: https://govukverify.atlassian.net/browse/F2F-586?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ