### PR TITLE
F2F-593:Added environmentvariables to stub template

### DIFF
--- a/cic-ipv-stub/template.yaml
+++ b/cic-ipv-stub/template.yaml
@@ -51,7 +51,7 @@ Mappings:
     production:
       IPVStubID: "C910A762"
 
-EnvironmentVariables: # This is all the environment specific environment variables that don't belong in globals.
+  EnvironmentVariables: # This is all the environment specific environment variables that don't belong in globals.
     dev:
       DNSSUFFIX: review-c.dev.account.gov.uk
     build:
@@ -142,11 +142,10 @@ Resources:
   StubApiCustomDomainName:
     Type: AWS::ApiGateway::DomainName
     Properties:
-      DomainName: 
-        - !Sub
-          - "ipvstub.${DNSSUFFIX}"
-          - DNSSUFFIX:
-             !FindInMap [ EnvironmentVariables, !Ref Environment, DNSSUFFIX ]
+      DomainName: !Sub
+        - "ipvstub.${DNSSUFFIX}"
+        - DNSSUFFIX:
+            !FindInMap [ EnvironmentVariables, !Ref Environment, DNSSUFFIX ]
       EndpointConfiguration:
         Types:
           - REGIONAL

--- a/cic-ipv-stub/template.yaml
+++ b/cic-ipv-stub/template.yaml
@@ -51,6 +51,18 @@ Mappings:
     production:
       IPVStubID: "C910A762"
 
+EnvironmentVariables: # This is all the environment specific environment variables that don't belong in globals.
+    dev:
+      DNSSUFFIX: review-c.dev.account.gov.uk
+    build:
+      DNSSUFFIX: review-c.build.account.gov.uk
+    staging:
+      DNSSUFFIX: review-c.staging.account.gov.uk
+    integration:
+      DNSSUFFIX: review-c.integration.account.gov.uk
+    production:
+      DNSSUFFIX: review-c.account.gov.uk
+
 Conditions:
   CreateDevResources: !Equals
     - !Ref Environment

--- a/cic-ipv-stub/template.yaml
+++ b/cic-ipv-stub/template.yaml
@@ -169,8 +169,7 @@ Resources:
     DependsOn: "StubApiCustomDomainName"
     Properties:
       DomainName: !Ref StubApiCustomDomainName
-      ApiId:
-        Fn::ImportValue: cic-cri-IPVStubApiGw
+      RestApiId: !Ref IPVStubApiGw
       Stage: !Ref Environment
 
   # Redirect ---------------------------------------


### PR DESCRIPTION
### What changed

Added dns suffix environment variables to the stub template

### Why did it change

Deployment was failing due to missing env var.

### Issue trackin
- [F2F-593](https://govukverify.atlassian.net/browse/F2F-593)



[F2F-593]: https://govukverify.atlassian.net/browse/F2F-593?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ