### PR TITLE
[F2F-657] - Add shared_claims Flag to IPV stub

### DIFF
--- a/src/tests/unit/services/SessionRequestProcessor.test.ts
+++ b/src/tests/unit/services/SessionRequestProcessor.test.ts
@@ -238,7 +238,7 @@ describe("SessionRequestProcessor", () => {
 		);
 		// the next assertion checks that the value has no more than 10 digits, i.e. is in secs not ms
 		// this will break in the year 2286!
-		const actualExpiryDate = mockCicService.createAuthSession.mock.calls[0][0]["expiryDate"];
+		const actualExpiryDate = mockCicService.createAuthSession.mock.calls[0][0].expiryDate;
 		expect(actualExpiryDate).toBeLessThan(10000000000);
 		jest.useRealTimers();
 	});

--- a/src/tests/unit/services/UserInfoRequestProcessorNoConfiguration.test.ts
+++ b/src/tests/unit/services/UserInfoRequestProcessorNoConfiguration.test.ts
@@ -3,7 +3,7 @@ import { mock } from "jest-mock-extended";
 import { Logger } from "@aws-lambda-powertools/logger";
 
 // arrange test data before importing the class under test
-process.env["SESSION_TABLE"] = "";
+process.env.SESSION_TABLE = "";
 
 import { UserInfoRequestProcessor } from "../../../services/UserInfoRequestProcessor";
 


### PR DESCRIPTION
### What changed

Adding flag addSharedClaims to the IPV Stub in CIC to enable testing of scenarios where IPV do not provide us with shared_claims information 

### Issue tracking
https://govukverify.atlassian.net/browse/F2F-657

```
{
    "target": "https://api-cic-cri-api.review-c.dev.account.gov.uk/",
    "addSharedClaims": false
}
```

![image](https://github.com/alphagov/di-ipv-cri-cic-api/assets/13416125/0b496b9e-c8c6-44c3-9f4c-aefdddb8f93c)
