### PR TITLE
F2F-720 DataTraceEnabled switched based on env, + tests

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -130,6 +130,9 @@ Conditions:
     - !Equals [!Ref Environment, staging]
     - !Equals [!Ref Environment, integration]
     - !Equals [!Ref Environment, production]
+  IsPersonalIdentifiableInformationEnvironment: !Or
+    - !Equals [!Ref Environment, integration]
+    - !Equals [!Ref Environment, production]
   UseCodeSigning:
     Fn::Not:
       - Fn::Equals:
@@ -268,7 +271,11 @@ Resources:
           MetricsEnabled: true
           ThrottlingBurstLimit: 400
           ThrottlingRateLimit: 200
-          DataTraceEnabled: true
+          # Disable data trace in production and integration to avoid logging customer sensitive information
+          DataTraceEnabled: !If
+            - IsPersonalIdentifiableInformationEnvironment
+            - false
+            - true
           HttpMethod: "*"
           ResourcePath: "/*"
       Tags:

--- a/src/tests/infra/template.test.ts
+++ b/src/tests/infra/template.test.ts
@@ -1,4 +1,4 @@
-import { Template, Capture, Match } from "@aws-cdk/assertions";
+import { Template, Match } from "@aws-cdk/assertions";
 const { schema } = require("yaml-cfn");
 import { readFileSync } from "fs";
 import { load } from "js-yaml";
@@ -39,8 +39,24 @@ describe("Infra", () => {
 		});
 	});
 
-	it.skip("The template contains two API gateway resource", () => {
+	it("The template contains one API gateway resource", () => {
 		template.resourceCountIs("AWS::Serverless::Api", 1);
+	});
+
+	it("Each API Gateway should have TracingEnabled", () => {
+		const apiGateways = template.findResources("AWS::Serverless::Api");
+		const apiGatewayList = Object.keys(apiGateways);
+		apiGatewayList.forEach((apiGatewayId) => {
+			expect(apiGateways[apiGatewayId].Properties.TracingEnabled).toEqual(true);
+		});
+	});
+
+	it("Each API Gateway should have MethodSettings defined", () => {
+		const apiGateways = template.findResources("AWS::Serverless::Api");
+		const apiGatewayList = Object.keys(apiGateways);
+		apiGatewayList.forEach((apiGatewayId) => {
+			expect(apiGateways[apiGatewayId].Properties.MethodSettings).toBeTruthy();
+		});
 	});
 
 	it.skip("Has tracing enabled on at least one API", () => {


### PR DESCRIPTION
## Proposed changes

### What changed

DataTraceEnabled is now set based on environments - it is false in environments which contain in PII

### Why did it change

avoid logging PII

### Issue tracking

- [F2F-720](https://govukverify.atlassian.net/browse/F2F-720)

## Checklists

### Environment variables or secrets

- [X] No environment variables or secrets were added or changed

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks

[F2F-720]: https://govukverify.atlassian.net/browse/F2F-720?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ