### PR TITLE
[F2F-766] - Updating IPV stub URLs

### DIFF
--- a/cic-ipv-stub/template.yaml
+++ b/cic-ipv-stub/template.yaml
@@ -54,10 +54,10 @@ Mappings:
   EnvironmentVariables: # This is all the environment specific environment variables that don't belong in globals.
     dev:
       DNSSUFFIX: review-c.dev.account.gov.uk
-      IPVSTUBURL: "https://api-cic-cri-api.review-c.dev.account.gov.uk/"
+      IPVSTUBURL: "https://cic-cri-front.review-c.dev.account.gov.uk"
     build:
       DNSSUFFIX: review-c.build.account.gov.uk
-      IPVSTUBURL: "https://api-cic-cri-api.review-c.build.account.gov.uk/"
+      IPVSTUBURL: "https://www.review-c.build.account.gov.uk"
     staging:
       DNSSUFFIX: review-c.staging.account.gov.uk
     integration:

--- a/cic-ipv-stub/template.yaml
+++ b/cic-ipv-stub/template.yaml
@@ -54,8 +54,10 @@ Mappings:
   EnvironmentVariables: # This is all the environment specific environment variables that don't belong in globals.
     dev:
       DNSSUFFIX: review-c.dev.account.gov.uk
+      IPVSTUBURL: "https://api-cic-cri-api.review-c.dev.account.gov.uk/"
     build:
       DNSSUFFIX: review-c.build.account.gov.uk
+      IPVSTUBURL: "https://api-cic-cri-api.review-c.build.account.gov.uk/"
     staging:
       DNSSUFFIX: review-c.staging.account.gov.uk
     integration:
@@ -342,7 +344,7 @@ Resources:
           CLIENT_ID: !FindInMap [Configuration, !Ref Environment, IPVStubID]
           REDIRECT_URI: !Sub "https://ipvstub.review-c.${Environment}.account.gov.uk/redirect"
           JWKS_URI: !Sub "https://api.review-c.${Environment}.account.gov.uk/.well-known/jwks.json"
-          OIDC_FRONT_BASE_URI: !Sub  "https://api-cic-cri-api.review-c.build.account.gov.uk"
+          OIDC_FRONT_BASE_URI: !FindInMap [ EnvironmentVariables, !Ref Environment, IPVSTUBURL ]
       Policies:
         - Statement:
             - Sid: KMSSignPolicy

--- a/cic-ipv-stub/template.yaml
+++ b/cic-ipv-stub/template.yaml
@@ -342,7 +342,7 @@ Resources:
           CLIENT_ID: !FindInMap [Configuration, !Ref Environment, IPVStubID]
           REDIRECT_URI: !Sub "https://ipvstub.review-c.${Environment}.account.gov.uk/redirect"
           JWKS_URI: !Sub "https://api.review-c.${Environment}.account.gov.uk/.well-known/jwks.json"
-          OIDC_FRONT_BASE_URI: !Sub  "https://api-cic-cri-api.review-c.dev.account.gov.uk"
+          OIDC_FRONT_BASE_URI: !Sub  "https://api-cic-cri-api.review-c.build.account.gov.uk"
       Policies:
         - Statement:
             - Sid: KMSSignPolicy


### PR DESCRIPTION
## Proposed changes

### What changed

The dev and build IPVSTUB URLs have been updated to hopefully work

### Why did it change

It wasn't working, an old URL was being called

### Issue tracking

- [F2F-766](https://govukverify.atlassian.net/browse/F2F-766)

## Checklists

### Environment variables or secrets

- [x] No environment variables or secrets were added or changed


[F2F-766]: https://govukverify.atlassian.net/browse/F2F-766?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ