### PR TITLE
Changed CICBackendURL output to use correct value for all env

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -957,9 +957,8 @@ Outputs:
   CICBackendURL:
     Description: "CIC Backend URL"
     Value: !Sub
-      - "https://api-${AWS::StackName}.${DNSSUFFIX}/"
-      - DNSSUFFIX:
-          !FindInMap [ EnvironmentVariables, !Ref Environment, DNSSUFFIX ]
+      - "https://${CICApiCustomDomainName}"
+      - CICApiCustomDomainName: !Ref CICApiCustomDomainName
     Export:
       Name: !Sub ${AWS::StackName}-CICBackendURL
   CICIPVStubExecuteURL:

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -957,8 +957,8 @@ Outputs:
   CICBackendURL:
     Description: "CIC Backend URL"
     Value: !Sub
-      - "https://${CICApiCustomDomainName}"
-      - CICApiCustomDomainName: !Ref CICApiCustomDomainName
+      - "https://${CustomDomainName}"
+      - CustomDomainName: !Ref CICApiCustomDomainName
     Export:
       Name: !Sub ${AWS::StackName}-CICBackendURL
   CICIPVStubExecuteURL:

--- a/src/tests/infra/template.test.ts
+++ b/src/tests/infra/template.test.ts
@@ -148,16 +148,10 @@ describe("Infra", () => {
 		template.hasOutput("CICBackendURL", {
 			Value: {
 				"Fn::Sub": [
-					"https://api-${AWS::StackName}.${DNSSUFFIX}/",
+					"https://${CustomDomainName}",
 					{
-						DNSSUFFIX: {
-							"Fn::FindInMap": [
-								"EnvironmentVariables",
-								{
-									Ref: "Environment",
-								},
-								"DNSSUFFIX"
-							],
+						CustomDomainName: {
+								Ref: "CICApiCustomDomainName"
 						},
 					},
 				],


### PR DESCRIPTION
### What changed
Template Output CICBackendURL now uses value from CICApiCustomDomainName 

### Why did it change
The current value for CICBackendURL has incorrect value in environments other than development as it used the format api-{stack name}-{domainname}. cic back end domain name has only api without the stack name.

### Issue tracking
- [F2F-820](https://govukverify.atlassian.net/browse/F2F-820)

## Checklists

### Environment variables or secrets
CICBackendURL has been changed to use value from CICApiCustomDomainName in the template.


[F2F-820]: https://govukverify.atlassian.net/browse/F2F-820?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ