### PR TITLE
[F2F-850] Ensures user id is not logged

### DIFF
--- a/src/UserInfoHandler.ts
+++ b/src/UserInfoHandler.ts
@@ -33,7 +33,7 @@ class UserInfo implements LambdaInterface {
 			case ResourcesEnum.USERINFO:
 				if (event.httpMethod === "POST") {
 					try {
-						logger.info("Received userInfo request", { event });
+						logger.info("Received userInfo request", { requestId: event.requestContext.requestId });
 						return await UserInfoRequestProcessor.getInstance(logger, metrics).processRequest(event);
 					} catch (error) {
 						logger.error({

--- a/src/UserInfoHandler.ts
+++ b/src/UserInfoHandler.ts
@@ -33,11 +33,11 @@ class UserInfo implements LambdaInterface {
 			case ResourcesEnum.USERINFO:
 				if (event.httpMethod === "POST") {
 					try {
-						logger.info("Received userInfo request:", { event });
+						logger.info("Received userInfo request", { event });
 						return await UserInfoRequestProcessor.getInstance(logger, metrics).processRequest(event);
 					} catch (error) {
 						logger.error({
-							message: "An error has occurred.",
+							message: "An error has occurred when processing the request",
 							error,
 							messageCode: MessageCodes.SERVER_ERROR,
 						});

--- a/src/services/CicService.ts
+++ b/src/services/CicService.ts
@@ -209,18 +209,18 @@ export class CicService {
 		};
 
 		this.logger.info("Sending message to TxMA", {
-			messageBody: event,
+			event_name: event.event_name,
 		});
 		try {
 			await sqsClient.send(new SendMessageCommand(params));
 			this.logger.info("Sent message to TxMA", {
-				messageBody: event,
+				event_name: event.event_name,
 			});
 		} catch (error) {
 			this.logger.error("got error ", {
 				error,
 			});
-			throw new AppError("sending event - failed ", HttpCodesEnum.SERVER_ERROR);
+			throw new AppError("Sending event - failed ", HttpCodesEnum.SERVER_ERROR);
 		}
 	}
 

--- a/src/services/UserInfoRequestProcessor.ts
+++ b/src/services/UserInfoRequestProcessor.ts
@@ -80,9 +80,6 @@ export class UserInfoRequestProcessor {
 			return new Response(HttpCodesEnum.SERVER_ERROR, "Server Error");
 		}
 
-		// add sessionId to all subsequent log messages
-		this.logger.appendKeys({ sessionId: sub });
-
 		let session: ISessionItem | undefined;
 		let personInfo: PersonIdentityItem | undefined;
 		try {
@@ -95,7 +92,6 @@ export class UserInfoRequestProcessor {
 			}
 		} catch (error) {
 			this.logger.error("Error finding session", {
-				sessionId: sub,
 				error,
 				messageCode: MessageCodes.SERVER_ERROR,
 			});
@@ -130,14 +126,13 @@ export class UserInfoRequestProcessor {
 			}
 		} catch (error) {
 			this.logger.error("Error finding person", {
-				sessionId: sub,
 				error,
 				messageCode: MessageCodes.SERVER_ERROR,
 			});
 			return new Response(HttpCodesEnum.SERVER_ERROR, "Server Error");
 		}
 
-		this.logger.info("Found Person");
+		this.logger.info("Found person by session ID");
   
 		this.metrics.addMetric("found person", MetricUnits.Count, 1);
 		

--- a/src/tests/unit/services/UserInfoRequestProcessor.test.ts
+++ b/src/tests/unit/services/UserInfoRequestProcessor.test.ts
@@ -112,9 +112,6 @@ describe("UserInfoRequestProcessor", () => {
 		expect(logger.appendKeys).toHaveBeenCalledWith({
 			govuk_signin_journey_id: "sdfssg",
 		});
-		expect(logger.appendKeys).toHaveBeenCalledWith({
-			sessionId: "sessionId",
-		});
 	});
 
 	it("Return 401 when Authorization header is missing in the request", async () => {
@@ -234,9 +231,6 @@ describe("UserInfoRequestProcessor", () => {
 		expect(logger.appendKeys).toHaveBeenCalledWith({
 			govuk_signin_journey_id: "sdfssg",
 		});
-		expect(logger.appendKeys).toHaveBeenCalledWith({
-			sessionId: "sessionId",
-		});
 		expect(logger.error).toHaveBeenCalledWith(
 			expect.anything(),
 			expect.objectContaining({
@@ -261,9 +255,6 @@ describe("UserInfoRequestProcessor", () => {
 		expect(logger.appendKeys).toHaveBeenCalledWith({
 			govuk_signin_journey_id: "sdfssg",
 		});
-		expect(logger.appendKeys).toHaveBeenCalledWith({
-			sessionId: "sessionId",
-		});
 		expect(logger.error).toHaveBeenCalledWith(
 			expect.anything(),
 			expect.objectContaining({
@@ -283,9 +274,6 @@ describe("UserInfoRequestProcessor", () => {
 		expect(logger.error).toHaveBeenCalledTimes(1);
 		expect(logger.appendKeys).toHaveBeenCalledWith({
 			govuk_signin_journey_id: "sdfssg",
-		});
-		expect(logger.appendKeys).toHaveBeenCalledWith({
-			sessionId: "sessionId",
 		});
 		expect(logger.error).toHaveBeenCalledWith(
 			expect.anything(),
@@ -311,9 +299,6 @@ describe("UserInfoRequestProcessor", () => {
 		expect(logger.appendKeys).toHaveBeenCalledWith({
 			govuk_signin_journey_id: "sdfssg",
 		});
-		expect(logger.appendKeys).toHaveBeenCalledWith({
-			sessionId: "sessionId",
-		});
 		expect(logger.error).toHaveBeenCalledWith(
 			expect.anything(),
 			expect.objectContaining({
@@ -337,9 +322,6 @@ describe("UserInfoRequestProcessor", () => {
 		expect(logger.error).toHaveBeenCalledWith("Failed to write TXMA event CIC_CRI_VC_ISSUED to SQS queue.", expect.anything());
 		expect(logger.appendKeys).toHaveBeenCalledWith({
 			govuk_signin_journey_id: "sdfssg",
-		});
-		expect(logger.appendKeys).toHaveBeenCalledWith({
-			sessionId: "sessionId",
 		});
 		expect(logger.error).toHaveBeenCalledTimes(2);
 		expect(out.body).toEqual(JSON.stringify({

--- a/src/tests/unit/services/UserInfoRequestProcessor.test.ts
+++ b/src/tests/unit/services/UserInfoRequestProcessor.test.ts
@@ -112,6 +112,9 @@ describe("UserInfoRequestProcessor", () => {
 		expect(logger.appendKeys).toHaveBeenCalledWith({
 			govuk_signin_journey_id: "sdfssg",
 		});
+		expect(logger.appendKeys).toHaveBeenCalledWith({
+			sessionId: "sessionId",
+		});
 	});
 
 	it("Return 401 when Authorization header is missing in the request", async () => {
@@ -231,6 +234,9 @@ describe("UserInfoRequestProcessor", () => {
 		expect(logger.appendKeys).toHaveBeenCalledWith({
 			govuk_signin_journey_id: "sdfssg",
 		});
+		expect(logger.appendKeys).toHaveBeenCalledWith({
+			sessionId: "sessionId",
+		});
 		expect(logger.error).toHaveBeenCalledWith(
 			expect.anything(),
 			expect.objectContaining({
@@ -255,6 +261,9 @@ describe("UserInfoRequestProcessor", () => {
 		expect(logger.appendKeys).toHaveBeenCalledWith({
 			govuk_signin_journey_id: "sdfssg",
 		});
+		expect(logger.appendKeys).toHaveBeenCalledWith({
+			sessionId: "sessionId",
+		});
 		expect(logger.error).toHaveBeenCalledWith(
 			expect.anything(),
 			expect.objectContaining({
@@ -274,6 +283,9 @@ describe("UserInfoRequestProcessor", () => {
 		expect(logger.error).toHaveBeenCalledTimes(1);
 		expect(logger.appendKeys).toHaveBeenCalledWith({
 			govuk_signin_journey_id: "sdfssg",
+		});
+		expect(logger.appendKeys).toHaveBeenCalledWith({
+			sessionId: "sessionId",
 		});
 		expect(logger.error).toHaveBeenCalledWith(
 			expect.anything(),
@@ -299,6 +311,9 @@ describe("UserInfoRequestProcessor", () => {
 		expect(logger.appendKeys).toHaveBeenCalledWith({
 			govuk_signin_journey_id: "sdfssg",
 		});
+		expect(logger.appendKeys).toHaveBeenCalledWith({
+			sessionId: "sessionId",
+		});
 		expect(logger.error).toHaveBeenCalledWith(
 			expect.anything(),
 			expect.objectContaining({
@@ -322,6 +337,9 @@ describe("UserInfoRequestProcessor", () => {
 		expect(logger.error).toHaveBeenCalledWith("Failed to write TXMA event CIC_CRI_VC_ISSUED to SQS queue.", expect.anything());
 		expect(logger.appendKeys).toHaveBeenCalledWith({
 			govuk_signin_journey_id: "sdfssg",
+		});
+		expect(logger.appendKeys).toHaveBeenCalledWith({
+			sessionId: "sessionId",
 		});
 		expect(logger.error).toHaveBeenCalledTimes(2);
 		expect(out.body).toEqual(JSON.stringify({


### PR DESCRIPTION
## Proposed changes

### What changed

We are no longer logging the session ID as that is the user ID and is considered PII

### Why did it change

We cannot log PII

### Screenshots

Before
![image](https://github.com/alphagov/di-ipv-cri-cic-api/assets/40401118/3fb58188-ad47-4574-93ea-a2438d6f4a62)
![image](https://github.com/alphagov/di-ipv-cri-cic-api/assets/40401118/0f5d658b-8faf-4bb0-816d-e06b7ccecc44)


After
![image](https://github.com/alphagov/di-ipv-cri-cic-api/assets/40401118/899785b3-08dc-4185-8b94-326c945fe57b)
![image](https://github.com/alphagov/di-ipv-cri-cic-api/assets/40401118/727be61a-36b2-457d-8a86-a44bfc119d9a)

### Issue tracking
- [F2F-850](https://govukverify.atlassian.net/browse/F2F-850)

## Checklists

### PII logging

- [x] Verified that no PII data is being logged

### Other considerations

- This is being merged into F2F-615 as it cannot be merged while the service is still logging PII


[F2F-850]: https://govukverify.atlassian.net/browse/F2F-850?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ