### PR TITLE
[F2F-846] Adds log to session endpoint

### DIFF
--- a/src/SessionHandler.ts
+++ b/src/SessionHandler.ts
@@ -33,6 +33,7 @@ class Session implements LambdaInterface {
 		switch (event.resource) {
 			case ResourcesEnum.SESSION:
 				try {
+					logger.info("Received session request", { requestId: event.requestContext.requestId });
 					return await SessionRequestProcessor.getInstance(logger, metrics).processRequest(event);
 				} catch (error) {
 					logger.error("An error has occurred.", {

--- a/src/services/SessionRequestProcessor.ts
+++ b/src/services/SessionRequestProcessor.ts
@@ -72,7 +72,6 @@ export class SessionRequestProcessor {
 		const requestBodyClientId = deserialisedRequestBody.client_id;
 		const clientIpAddress = event.headers["x-forwarded-for"];
 
-
 		let configClient: ClientConfig | undefined = undefined;
 		try {
 			const config = JSON.parse(CLIENT_CONFIG!) as ClientConfig[];


### PR DESCRIPTION
## Proposed changes

### What changed

Added log that could be helpful for debugging

### Why did it change

While checking for logs that might contain PII, I noticed that a log confirming the lambda has been successfully triggered as we have in other services was not present here

### Screenshots
![Screenshot 2023-06-27 at 4 27 44 pm](https://github.com/alphagov/di-ipv-cri-cic-api/assets/40401118/9b7240ed-8eb7-409a-a724-c2dda0b782aa)


### Issue tracking
- [F2F-846](https://govukverify.atlassian.net/browse/F2F-846)

## Checklists

### PII logging

- [x] Verified that no PII data is being logged


[F2F-846]: https://govukverify.atlassian.net/browse/F2F-846?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ