### PR TITLE
Fixed the test to provide absolute path for src directory

### DIFF
--- a/run-tests.sh
+++ b/run-tests.sh
@@ -13,7 +13,7 @@ CFN_CICBackendURL_NoQuotes=$(remove_quotes "$CFN_CICBackendURL")
 export DEV_CRI_CIC_API_URL=$(echo ${CFN_CICBackendURL_NoQuotes%/})
 export DEV_IPV_STUB_URL=$(remove_quotes $CFN_CICIPVStubExecuteURL)/start
 
-cd ./src; npm run test:e2e
+cd /src; npm run test:e2e
 error_code=$?
 
 cp -rf results $TEST_REPORT_ABSOLUTE_DIR


### PR DESCRIPTION
### What changed
run-tests.sh script was updated to use src dir path from root.

### Why did it change

Caused the test to fail once the platform codepipeline changes were applied as the run-tests.sh script incorrectly assumed to be running in root dir.

### Issue tracking

- [F2F-895](https://govukverify.atlassian.net/browse/F2F-895)

## Checklists

### PII logging

- [x] Verified that no PII data is being logged

### Environment variables or secrets

- [ ] No environment variables or secrets were added or changed


[F2F-895]: https://govukverify.atlassian.net/browse/F2F-895?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ