### PR TITLE
Adds API codeowners to the tests repo aswell

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,4 +5,4 @@
 
 # The following allows QA to review changes to /tests directory
 
-tests/ @alphagov/di-ipv-kiwi-qa-codeowners
+tests/ @alphagov/di-ipv-kiwi-qa-codeowners @alphagov/di-ipv-kiwi-api-codeowners


### PR DESCRIPTION
## Proposed changes

### What changed

Added `@alphagov/di-ipv-kiwi-api-codeowners` to the list of code owners for the `/tests` repo so that we can approve test changes too

### Why did it change

Currently the QA team are the _only_ approvers for test changes which is blocking us when we make changes too unit tests etc

![image](https://github.com/alphagov/di-ipv-cri-cic-api/assets/40401118/fe36da85-b822-42b2-86a0-d0578017659d)

