### PR TITLE
Adding condition to skip output CICIPVStubExecuteURL in prod like env

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -134,6 +134,8 @@ Conditions:
     - !Equals [!Ref Environment, staging]
     - !Equals [!Ref Environment, integration]
     - !Equals [!Ref Environment, production]
+  IsNotProdLikeEnvironment: !Not
+    - !Condition IsProdLikeEnvironment
   IsPersonalIdentifiableInformationEnvironment: !Or
     - !Equals [!Ref Environment, integration]
     - !Equals [!Ref Environment, production]
@@ -962,6 +964,7 @@ Outputs:
     Export:
       Name: !Sub ${AWS::StackName}-CICBackendURL
   CICIPVStubExecuteURL:
+    Condition: IsNotProdLikeEnvironment
     Description: "CIC IPV Stub"
     Value:
       Fn::ImportValue: !Sub '${IPVStubStackName}-IPVStubExecuteUrl'


### PR DESCRIPTION
### What changed

Added a new condition IsNotProdLikeEnvironment to skip export of CICIPVStubExecuteURL as it is not needed in staging, integration and prod.

### Why did it change

The codepipeline deployment was failing in staging for cic api.

### Issue tracking
- [F2F-905](https://govukverify.atlassian.net/browse/F2F-905)

## Checklists

### Environment variables or secrets

- [ ] No environment variables or secrets were added or changed


[F2F-905]: https://govukverify.atlassian.net/browse/F2F-905?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ