### PR TITLE
[F2F-843] Stops loggings update command as it contains PII

### DIFF
--- a/src/services/CicService.ts
+++ b/src/services/CicService.ts
@@ -293,10 +293,10 @@ export class CicService {
 		});
 
 		this.logger.info({
-			message:
-				"Saving session data in DynamoDB: " +
-				JSON.stringify([putSessionCommand]),
+			message: "Saving session data in DynamoDB",
+			tableName: this.tableName,
 		});
+
 		try {
 			await this.dynamo.send(putSessionCommand);
 			this.logger.info("Successfully created session in dynamodb");


### PR DESCRIPTION
## Proposed changes

### What changed

Logs table name instead of updated command

### Why did it change

The update command contains `sub`/`user id`

### Screenshots

Before
<img width="1331" alt="image" src="https://github.com/alphagov/di-ipv-cri-cic-api/assets/40401118/42c5def9-8fc0-4637-9395-1bcf5671b66d">

After
<img width="955" alt="Screenshot 2023-07-05 at 12 29 15 pm" src="https://github.com/alphagov/di-ipv-cri-cic-api/assets/40401118/64019b70-6071-46e6-9378-7c51631bc140">

### Issue tracking
- [F2F-843](https://govukverify.atlassian.net/browse/F2F-843)

## Checklists

### PII logging

- [x] Verified that no PII data is being logged



[F2F-843]: https://govukverify.atlassian.net/browse/F2F-843?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ