### PR TITLE
[F2F-962] Update main stack url for IPVStub

### DIFF
--- a/cic-ipv-stub/template.yaml
+++ b/cic-ipv-stub/template.yaml
@@ -54,10 +54,10 @@ Mappings:
   EnvironmentVariables: # This is all the environment specific environment variables that don't belong in globals.
     dev:
       DNSSUFFIX: review-c.dev.account.gov.uk
-      IPVSTUBURL: "https://cic-cri-front.review-c.dev.account.gov.uk"
+      IPVSTUBURL: "https://api-cic-cri-api.review-c.dev.account.gov.uk"
     build:
       DNSSUFFIX: review-c.build.account.gov.uk
-      IPVSTUBURL: "https://www.review-c.build.account.gov.uk"
+      IPVSTUBURL: "https://api.review-c.build.account.gov.uk"
     staging:
       DNSSUFFIX: review-c.staging.account.gov.uk
     integration:


### PR DESCRIPTION
## Proposed changes

### What changed

Fixing change done [here](https://github.com/alphagov/di-ipv-cri-cic-api/pull/219/files) to correctly set the BE stack url so IPVStub is able to fetch the WellKnown endpoint