### PR TITLE
[CIC-962] Update main stack url for IPVStub

### DIFF
--- a/cic-ipv-stub/src/handlers/startCicCheck.ts
+++ b/cic-ipv-stub/src/handlers/startCicCheck.ts
@@ -87,7 +87,7 @@ export const handler = async (
       request,
       responseType: "code",
       clientId: config.clientId,
-      AuthorizeLocation: `${process.env.OIDC_FRONT_BASE_URI}/oauth2/authorize?request=${request}&response_type=code&client_id=${config.clientId}`,
+      AuthorizeLocation: `${process.env.OIDC_API_BASE_URI}/oauth2/authorize?request=${request}&response_type=code&client_id=${config.clientId}`,
     }),
   };
 };
@@ -104,7 +104,7 @@ export function getConfig(): {
     process.env.JWKS_URI == null ||
     process.env.CLIENT_ID == null ||
     process.env.SIGNING_KEY == null ||
-    process.env.OIDC_FRONT_BASE_URI == null
+    process.env.OIDC_API_BASE_URI == null
   ) {
     throw new Error("Missing configuration");
   }
@@ -114,7 +114,7 @@ export function getConfig(): {
     jwksUri: process.env.JWKS_URI,
     clientId: process.env.CLIENT_ID,
     signingKey: process.env.SIGNING_KEY,
-    oidcUri: process.env.OIDC_FRONT_BASE_URI,
+    oidcUri: process.env.OIDC_API_BASE_URI,
   };
 }
 

--- a/cic-ipv-stub/src/tests/startCicCheck.test.ts
+++ b/cic-ipv-stub/src/tests/startCicCheck.test.ts
@@ -79,7 +79,7 @@ describe("Start CIC Check Endpoint", () => {
     process.env.JWKS_URI = "test.com/.well-known/jwks.json";
     process.env.CLIENT_ID = "test-id";
     process.env.SIGNING_KEY = "key-id";
-    process.env.OIDC_FRONT_BASE_URI = "test-target.com";
+    process.env.OIDC_API_BASE_URI = "test-target.com";
 
     const response = await handler(startDefault);
     expect(response.statusCode).toBe(201);

--- a/cic-ipv-stub/template.yaml
+++ b/cic-ipv-stub/template.yaml
@@ -54,10 +54,10 @@ Mappings:
   EnvironmentVariables: # This is all the environment specific environment variables that don't belong in globals.
     dev:
       DNSSUFFIX: review-c.dev.account.gov.uk
-      IPVSTUBURL: "https://cic-cri-front.review-c.dev.account.gov.uk"
+      BASEAPIURL: "https://api-cic-cri-api.review-c.dev.account.gov.uk"
     build:
       DNSSUFFIX: review-c.build.account.gov.uk
-      IPVSTUBURL: "https://www.review-c.build.account.gov.uk"
+      BASEAPIURL: "https://api.review-c.build.account.gov.uk"
     staging:
       DNSSUFFIX: review-c.staging.account.gov.uk
     integration:
@@ -344,7 +344,7 @@ Resources:
           CLIENT_ID: !FindInMap [Configuration, !Ref Environment, IPVStubID]
           REDIRECT_URI: !Sub "https://ipvstub.review-c.${Environment}.account.gov.uk/redirect"
           JWKS_URI: !Sub "https://api.review-c.${Environment}.account.gov.uk/.well-known/jwks.json"
-          OIDC_FRONT_BASE_URI: !FindInMap [ EnvironmentVariables, !Ref Environment, IPVSTUBURL ]
+          OIDC_API_BASE_URI: !FindInMap [ EnvironmentVariables, !Ref Environment, BASEAPIURL ]
       Policies:
         - Statement:
             - Sid: KMSSignPolicy


### PR DESCRIPTION
## Proposed changes

### What changed

Fixing change done [here](https://github.com/alphagov/di-ipv-cri-cic-api/pull/219/files) to correctly set the BE stack url so IPVStub is able to fetch the WellKnown endpoint

<img width="1075" alt="image" src="https://github.com/alphagov/di-ipv-cri-cic-api/assets/13416125/5ffa2947-42d3-4d7a-b1ec-1146a070933f">
