### PR TITLE
F2F-779: Set reserved concurrencies for Lambdas in non-DEV environments

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,9 @@ sam deploy --resolve-s3 --stack-name "YOUR_STACK_NAME" --confirm-changeset --con
   "CodeSigningConfigArn=\"none\" Environment=\"dev\" PermissionsBoundary=\"none\" SecretPrefix=\"none\" VpcStackName=\"vpc-cri\" CommonStackName=\"common-cri-api\" L2DynamoStackName=\"infra-l2-dynamo\" L2KMSStackName=\"infra-l2-kms\" PowertoolsLogLevel=\"DEBUG\""
 ```
 
+If you need the reserved concurrencies set in DEV then add `ApplyReservedConcurrencyInDev=\"true\"` in to the `--parameter-overrides`.
+Please only do this whilst you need them, if lots of stacks are deployed with these in DEV then deployments will start failing.
+
 # Generating JWKS
 
 The public JWKS is not generated automatically when deploying a stack. In order to run the E2E tests, or to successfully call the ./wellknown/jwks endpoint, the key needs to be generated. It can be done as follows:

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -181,6 +181,9 @@ Conditions:
   DeployAlarms: !Or
     - Condition: IsProdLikeEnvironment
     - !Equals [!Ref DeployAlarmsInNonProdLikeEnvironment, true]
+  DeployConcurrencyAlarms: !And
+    - Condition: DeployAlarms
+    - Condition: ApplyReservedConcurrency
   
 
 Globals:
@@ -2328,7 +2331,7 @@ Resources:
 
   UserInfoConcurrency80Alarm:
     Type: AWS::CloudWatch::Alarm
-    Condition: "DeployAlarms"
+    Condition: "DeployConcurrencyAlarms"
     Properties:
       ActionsEnabled: true
       AlarmActions:
@@ -2347,16 +2350,13 @@ Resources:
       Period: 60 # This is the minimum value for the AWS Namespace
       EvaluationPeriods: 1
       DatapointsToAlarm: 1
-      Threshold: !If
-        - ApplyReservedConcurrency
-        - !Ref LambdaConcurrencyThreshold
-        - !Ref AWS::NoValue
+      Threshold: !Ref LambdaConcurrencyThreshold
       ComparisonOperator: GreaterThanThreshold
       TreatMissingData: notBreaching
   
   TokenConcurrency80Alarm:
     Type: AWS::CloudWatch::Alarm
-    Condition: "DeployAlarms"
+    Condition: "DeployConcurrencyAlarms"
     Properties:
       ActionsEnabled: true
       AlarmActions:
@@ -2375,16 +2375,13 @@ Resources:
       Period: 60 # This is the minimum value for the AWS Namespace
       EvaluationPeriods: 1
       DatapointsToAlarm: 1
-      Threshold: !If
-        - ApplyReservedConcurrency
-        - !Ref LambdaConcurrencyThreshold
-        - !Ref AWS::NoValue
+      Threshold: !Ref LambdaConcurrencyThreshold
       ComparisonOperator: GreaterThanThreshold
       TreatMissingData: notBreaching
   
   AuthorizationConcurrency80Alarm:
     Type: AWS::CloudWatch::Alarm
-    Condition: "DeployAlarms"
+    Condition: "DeployConcurrencyAlarms"
     Properties:
       ActionsEnabled: true
       AlarmActions:
@@ -2403,16 +2400,13 @@ Resources:
       Period: 60 # This is the minimum value for the AWS Namespace
       EvaluationPeriods: 1
       DatapointsToAlarm: 1
-      Threshold: !If
-        - ApplyReservedConcurrency
-        - !Ref LambdaConcurrencyThreshold
-        - !Ref AWS::NoValue
+      Threshold: !Ref LambdaConcurrencyThreshold
       ComparisonOperator: GreaterThanThreshold
       TreatMissingData: notBreaching
 
   ClaimedIdentityConcurrency80Alarm:
     Type: AWS::CloudWatch::Alarm
-    Condition: "DeployAlarms"
+    Condition: "DeployConcurrencyAlarms"
     Properties:
       ActionsEnabled: true
       AlarmActions:
@@ -2431,16 +2425,13 @@ Resources:
       Period: 60 # This is the minimum value for the AWS Namespace
       EvaluationPeriods: 1
       DatapointsToAlarm: 1
-      Threshold: !If
-        - ApplyReservedConcurrency
-        - !Ref LambdaConcurrencyThreshold
-        - !Ref AWS::NoValue
+      Threshold: !Ref LambdaConcurrencyThreshold
       ComparisonOperator: GreaterThanThreshold
       TreatMissingData: notBreaching
 
   SessionConcurrency80Alarm:
     Type: AWS::CloudWatch::Alarm
-    Condition: "DeployAlarms"
+    Condition: "DeployConcurrencyAlarms"
     Properties:
       ActionsEnabled: true
       AlarmActions:
@@ -2459,16 +2450,13 @@ Resources:
       Period: 60 # This is the minimum value for the AWS Namespace
       EvaluationPeriods: 1
       DatapointsToAlarm: 1
-      Threshold: !If
-        - ApplyReservedConcurrency
-        - !Ref LambdaConcurrencyThreshold
-        - !Ref AWS::NoValue
+      Threshold: !Ref LambdaConcurrencyThreshold
       ComparisonOperator: GreaterThanThreshold
       TreatMissingData: notBreaching
 
   JsonWebKeysConcurrency80Alarm:
     Type: AWS::CloudWatch::Alarm
-    Condition: "DeployAlarms"
+    Condition: "DeployConcurrencyAlarms"
     Properties:
       ActionsEnabled: true
       AlarmActions:
@@ -2487,10 +2475,7 @@ Resources:
       Period: 60 # This is the minimum value for the AWS Namespace
       EvaluationPeriods: 1
       DatapointsToAlarm: 1
-      Threshold: !If
-        - ApplyReservedConcurrency
-        - !Ref LambdaConcurrencyThreshold
-        - !Ref AWS::NoValue
+      Threshold: !Ref LambdaConcurrencyThreshold
       ComparisonOperator: GreaterThanThreshold
       TreatMissingData: notBreaching
 
@@ -2812,7 +2797,7 @@ Resources:
 
   ConcurrencyAlarmDashboard:
     Type: AWS::CloudWatch::Dashboard
-    Condition: DeployAlarms
+    Condition: DeployConcurrencyAlarms
     Properties:
       DashboardName: !Sub '${AWS::StackName}-Concurrency-Alarm-Overview'
       DashboardBody:

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -2340,7 +2340,7 @@ Resources:
         - !ImportValue platform-alarm-topic-critical-alert
       InsufficientDataActions: []
       AlarmDescription: !Sub "Trigger the alarm if over 80% of reserved concurrency is used. ${SupportManualURL}"
-      AlarmName: !Sub "${AWS::StackName}-${UserInfoFunction}-concurrency"
+      AlarmName: !Sub "${AWS::StackName}-UserInfoFunction-concurrency"
       MetricName: ConcurrentExecutions
       Namespace: AWS/Lambda
       Dimensions:
@@ -2365,7 +2365,7 @@ Resources:
         - !ImportValue platform-alarm-topic-critical-alert
       InsufficientDataActions: []
       AlarmDescription: !Sub "Trigger the alarm if over 80% of reserved concurrency is used. ${SupportManualURL}"
-      AlarmName: !Sub "${AWS::StackName}-${TokenFunction}-concurrency"
+      AlarmName: !Sub "${AWS::StackName}-TokenFunction-concurrency"
       MetricName: ConcurrentExecutions
       Namespace: AWS/Lambda
       Dimensions:
@@ -2390,7 +2390,7 @@ Resources:
         - !ImportValue platform-alarm-topic-critical-alert
       InsufficientDataActions: []
       AlarmDescription: !Sub "Trigger the alarm if over 80% of reserved concurrency is used. ${SupportManualURL}"
-      AlarmName: !Sub "${AWS::StackName}-${AuthorizationFunction}-concurrency"
+      AlarmName: !Sub "${AWS::StackName}-AuthorizationFunction-concurrency"
       MetricName: ConcurrentExecutions
       Namespace: AWS/Lambda
       Dimensions:
@@ -2415,7 +2415,7 @@ Resources:
         - !ImportValue platform-alarm-topic-critical-alert
       InsufficientDataActions: []
       AlarmDescription: !Sub "Trigger the alarm if over 80% of reserved concurrency is used. ${SupportManualURL}"
-      AlarmName: !Sub "${AWS::StackName}-${ClaimedIdentityFunction}-concurrency"
+      AlarmName: !Sub "${AWS::StackName}-ClaimedIdentityFunction-concurrency"
       MetricName: ConcurrentExecutions
       Namespace: AWS/Lambda
       Dimensions:
@@ -2440,7 +2440,7 @@ Resources:
         - !ImportValue platform-alarm-topic-critical-alert
       InsufficientDataActions: []
       AlarmDescription: !Sub "Trigger the alarm if over 80% of reserved concurrency is used. ${SupportManualURL}"
-      AlarmName: !Sub "${AWS::StackName}-${SessionFunction}-concurrency"
+      AlarmName: !Sub "${AWS::StackName}-SessionFunction-concurrency"
       MetricName: ConcurrentExecutions
       Namespace: AWS/Lambda
       Dimensions:
@@ -2465,7 +2465,7 @@ Resources:
         - !ImportValue platform-alarm-topic-slack-warning-alert
       InsufficientDataActions: []
       AlarmDescription: !Sub "Trigger the alarm if over 80% of JsonWeb Keys concurrency is used. ${SupportManualURL}"
-      AlarmName: !Sub "${AWS::StackName}-${JsonWebKeysFunction}-concurrency"
+      AlarmName: !Sub "${AWS::StackName}-JsonWebKeysFunction-concurrency"
       MetricName: ConcurrentExecutions
       Namespace: AWS/Lambda
       Dimensions:
@@ -2492,7 +2492,7 @@ Resources:
         - !ImportValue platform-alarm-topic-critical-alert
       InsufficientDataActions: []
       AlarmDescription: !Sub "Trigger if the ${ClaimedIdentityFunction} lambda throttles. ${SupportManualURL}"
-      AlarmName: !Sub "${AWS::StackName}-${ClaimedIdentityFunction}-throttles"
+      AlarmName: !Sub "${AWS::StackName}-ClaimedIdentityFunction-throttles"
       MetricName: Throttles
       Namespace: AWS/Lambda
       Statistic: Sum
@@ -2517,7 +2517,7 @@ Resources:
         - !ImportValue platform-alarm-topic-critical-alert
       InsufficientDataActions: []
       AlarmDescription: !Sub "Trigger if the ${SessionFunction} lambda throttles. ${SupportManualURL}"
-      AlarmName: !Sub "${AWS::StackName}-${SessionFunction}-throttles"
+      AlarmName: !Sub "${AWS::StackName}-SessionFunction-throttles"
       MetricName: Throttles
       Namespace: AWS/Lambda
       Statistic: Sum
@@ -2542,7 +2542,7 @@ Resources:
         - !ImportValue platform-alarm-topic-critical-alert
       InsufficientDataActions: []
       AlarmDescription: !Sub "Trigger if the ${JsonWebKeysFunction} lambda throttles. ${SupportManualURL}"
-      AlarmName: !Sub "${AWS::StackName}-${JsonWebKeysFunction}-throttles"
+      AlarmName: !Sub "${AWS::StackName}-JsonWebKeysFunction-throttles"
       MetricName: Throttles
       Namespace: AWS/Lambda
       Statistic: Sum
@@ -2567,7 +2567,7 @@ Resources:
         - !ImportValue platform-alarm-topic-critical-alert
       InsufficientDataActions: []
       AlarmDescription: !Sub "Trigger if the ${AuthorizationFunction} lambda throttles. ${SupportManualURL}"
-      AlarmName: !Sub "${AWS::StackName}-${AuthorizationFunction}-throttles"
+      AlarmName: !Sub "${AWS::StackName}-AuthorizationFunction-throttles"
       MetricName: Throttles
       Namespace: AWS/Lambda
       Statistic: Sum
@@ -2592,7 +2592,7 @@ Resources:
         - !ImportValue platform-alarm-topic-critical-alert
       InsufficientDataActions: []
       AlarmDescription: !Sub "Trigger if the ${TokenFunction} lambda throttles. ${SupportManualURL}"
-      AlarmName: !Sub "${AWS::StackName}-${TokenFunction}-throttles"
+      AlarmName: !Sub "${AWS::StackName}-TokenFunction-throttles"
       MetricName: Throttles
       Namespace: AWS/Lambda
       Statistic: Sum
@@ -2617,7 +2617,7 @@ Resources:
         - !ImportValue platform-alarm-topic-critical-alert
       InsufficientDataActions: []
       AlarmDescription: !Sub "Trigger if the ${UserInfoFunction} lambda throttles. ${SupportManualURL}"
-      AlarmName: !Sub "${AWS::StackName}-${UserInfoFunction}-throttles"
+      AlarmName: !Sub "${AWS::StackName}-UserInfoFunction-throttles"
       MetricName: Throttles
       Namespace: AWS/Lambda
       Statistic: Sum

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -49,7 +49,7 @@ Parameters:
   DeployAlarmsInNonProdLikeEnvironment:
     Description: "Set to the string value `true` to deploy alarms in a DEV environment"
     Type: String
-    Default: "true"
+    Default: true
   SupportManualURL:
     Description: "Link to the CIC support manual"
     Type: String

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -58,6 +58,10 @@ Parameters:
     Description: "Reserved concurrency for Lambdas running in non-DEV environments"
     Type: Number
     Default: 20
+  LambdaConcurrencyThreshold:
+    Description: "Threshold for Reserved concurrency running in non-DEV environments"
+    Type: Number
+    Default: 16  #80% of Lambda concurrency
   ApplyReservedConcurrencyInDev:
     Description: "Set to true to apply reserved concurrency when deploying in DEV environments"
     Type: String
@@ -100,35 +104,30 @@ Mappings:
       CLIENTS: '[{"jwksEndpoint":"https://ipvstub.review-c.dev.account.gov.uk/.well-known/jwks.json","clientId":"5C584572","redirectUri":"https://ipvstub.review-c.dev.account.gov.uk/redirect"}]'
       TXMAMESSAGERETENTIONPERIODDAYS: 604800 # Default: 7 days
       AUTHSESSIONTTL: "950400" # 11 days in seconds
-      LAMBDACONCURRENCY80THRESHOLD: 16
     build:
       ISSUER: "https://review-c.build.account.gov.uk"
       DNSSUFFIX: review-c.build.account.gov.uk
       CLIENTS: '[{"jwksEndpoint":"https://ipvstub.review-c.build.account.gov.uk/.well-known/jwks.json","clientId":"BD7B2A5D","redirectUri":"https://ipvstub.review-c.build.account.gov.uk/redirect"}]'
       TXMAMESSAGERETENTIONPERIODDAYS: 604800 # Default: 7 days
       AUTHSESSIONTTL: "950400" # 11 days in seconds
-      LAMBDACONCURRENCY80THRESHOLD: 16
     staging:
       ISSUER: "https://review-c.staging.account.gov.uk"
       DNSSUFFIX: review-c.staging.account.gov.uk
       CLIENTS: '[{"jwksEndpoint":"https://api.identity.staging.account.gov.uk/.well-known/jwks.json","clientId":"03A5A659-17AA-453F-B905-95D2804823D1","redirectUri":"https://identity.staging.account.gov.uk/credential-issuer/callback?id=claimedIdentity"}]'
       TXMAMESSAGERETENTIONPERIODDAYS: 604800 # Default: 7 days
       AUTHSESSIONTTL: "950400" # 11 days in seconds
-      LAMBDACONCURRENCY80THRESHOLD: 16
     integration:
       ISSUER: "https://review-c.integration.account.gov.uk"
       DNSSUFFIX: review-c.integration.account.gov.uk
       CLIENTS: '[{"jwksEndpoint":"https://api.identity.integration.account.gov.uk/.well-known/jwks.json", "clientId":"AE140E43-1987-4EE8-86CC-BEF19FC9FF3F", "redirectUri":"https://identity.integration.account.gov.uk/credential-issuer/callback?id=claimedIdentity"}]'
       TXMAMESSAGERETENTIONPERIODDAYS: 604800 # Default: 7 days
       AUTHSESSIONTTL: "950400" # 11 days in seconds
-      LAMBDACONCURRENCY80THRESHOLD: 16
     production:
       ISSUER: "https://review-c.account.gov.uk"
       DNSSUFFIX: review-c.account.gov.uk
       CLIENTS: '[{"jwksEndpoint":"https://api.identity.account.gov.uk/.well-known/jwks.json", "clientId":"C910A762-4BB2-400D-8F3D-4D7E6C84E342", "redirectUri":"https://identity.account.gov.uk/credential-issuer/callback?id=claimedIdentity"}]'
       TXMAMESSAGERETENTIONPERIODDAYS: 604800 # Default: 7 days
       AUTHSESSIONTTL: "950400" # 11 days in seconds
-      LAMBDACONCURRENCY80THRESHOLD: 16
   TxMAAccounts:
     # EVENTS is used to egress to TxMA.
     dev:
@@ -2348,7 +2347,10 @@ Resources:
       Period: 60 # This is the minimum value for the AWS Namespace
       EvaluationPeriods: 1
       DatapointsToAlarm: 1
-      Threshold: !FindInMap [ EnvironmentVariables, !Ref Environment, LAMBDACONCURRENCY80THRESHOLD ]
+      Threshold: !If
+        - ApplyReservedConcurrency
+        - !Ref LambdaConcurrencyThreshold
+        - !Ref AWS::NoValue
       ComparisonOperator: GreaterThanThreshold
       TreatMissingData: notBreaching
   
@@ -2373,7 +2375,10 @@ Resources:
       Period: 60 # This is the minimum value for the AWS Namespace
       EvaluationPeriods: 1
       DatapointsToAlarm: 1
-      Threshold: !FindInMap [ EnvironmentVariables, !Ref Environment, LAMBDACONCURRENCY80THRESHOLD ]
+      Threshold: !If
+        - ApplyReservedConcurrency
+        - !Ref LambdaConcurrencyThreshold
+        - !Ref AWS::NoValue
       ComparisonOperator: GreaterThanThreshold
       TreatMissingData: notBreaching
   
@@ -2398,7 +2403,10 @@ Resources:
       Period: 60 # This is the minimum value for the AWS Namespace
       EvaluationPeriods: 1
       DatapointsToAlarm: 1
-      Threshold: !FindInMap [ EnvironmentVariables, !Ref Environment, LAMBDACONCURRENCY80THRESHOLD ]
+      Threshold: !If
+        - ApplyReservedConcurrency
+        - !Ref LambdaConcurrencyThreshold
+        - !Ref AWS::NoValue
       ComparisonOperator: GreaterThanThreshold
       TreatMissingData: notBreaching
 
@@ -2423,7 +2431,10 @@ Resources:
       Period: 60 # This is the minimum value for the AWS Namespace
       EvaluationPeriods: 1
       DatapointsToAlarm: 1
-      Threshold: !FindInMap [ EnvironmentVariables, !Ref Environment, LAMBDACONCURRENCY80THRESHOLD ]
+      Threshold: !If
+        - ApplyReservedConcurrency
+        - !Ref LambdaConcurrencyThreshold
+        - !Ref AWS::NoValue
       ComparisonOperator: GreaterThanThreshold
       TreatMissingData: notBreaching
 
@@ -2448,7 +2459,10 @@ Resources:
       Period: 60 # This is the minimum value for the AWS Namespace
       EvaluationPeriods: 1
       DatapointsToAlarm: 1
-      Threshold: !FindInMap [ EnvironmentVariables, !Ref Environment, LAMBDACONCURRENCY80THRESHOLD ]
+      Threshold: !If
+        - ApplyReservedConcurrency
+        - !Ref LambdaConcurrencyThreshold
+        - !Ref AWS::NoValue
       ComparisonOperator: GreaterThanThreshold
       TreatMissingData: notBreaching
 
@@ -2473,7 +2487,10 @@ Resources:
       Period: 60 # This is the minimum value for the AWS Namespace
       EvaluationPeriods: 1
       DatapointsToAlarm: 1
-      Threshold: !FindInMap [EnvironmentVariables, !Ref Environment, LAMBDACONCURRENCY80THRESHOLD]
+      Threshold: !If
+        - ApplyReservedConcurrency
+        - !Ref LambdaConcurrencyThreshold
+        - !Ref AWS::NoValue
       ComparisonOperator: GreaterThanThreshold
       TreatMissingData: notBreaching
 

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -49,12 +49,15 @@ Parameters:
   DeployAlarmsInNonProdLikeEnvironment:
     Description: "Set to the string value `true` to deploy alarms in a DEV environment"
     Type: String
-    Default: true
+    Default: "true"
   SupportManualURL:
     Description: "Link to the CIC support manual"
     Type: String
     Default: 'https://govukverify.atlassian.net/wiki/spaces/FTFCRI/pages/3602251909/CIC+Support+Documentation'
-
+  LambdaConcurrency:
+    Description: "Reserved concurrency for Lambdas running in non-dev environments"
+    Type: Number
+    Default: 20
 
 Mappings:
   EnvironmentConfiguration: # This is where you store per-environment settings.
@@ -144,6 +147,8 @@ Conditions:
   CreateDevResources: !Equals
     - !Ref Environment
     - dev
+  IsNotDevEnvironment: !Not
+    - !Condition CreateDevResources
   IsProdLikeEnvironment: !Or
     - !Equals [!Ref Environment, staging]
     - !Equals [!Ref Environment, integration]
@@ -390,6 +395,10 @@ Resources:
       FunctionName: !Sub "CIC-ClaimedIdentity-${AWS::StackName}"
       Handler: ClaimedIdentityHandler.lambdaHandler
       CodeUri: ../src/
+      ReservedConcurrentExecutions: !If
+        - IsNotDevEnvironment
+        - !Ref LambdaConcurrency
+        - !Ref AWS::NoValue
       Environment:
         Variables:
           POWERTOOLS_SERVICE_NAME: ClaimedIdHandler
@@ -468,6 +477,10 @@ Resources:
       FunctionName: !Sub "User-Info-${AWS::StackName}"
       Handler: UserInfoHandler.lambdaHandler
       CodeUri: ../src/
+      ReservedConcurrentExecutions: !If
+        - IsNotDevEnvironment
+        - !Ref LambdaConcurrency
+        - !Ref AWS::NoValue
       Environment:
         Variables:
           POWERTOOLS_SERVICE_NAME: UserInfoHandler
@@ -565,6 +578,10 @@ Resources:
     Properties:
       FunctionName: !Sub "CIC-Session-${AWS::StackName}"
       Handler: SessionHandler.lambdaHandler
+      ReservedConcurrentExecutions: !If
+        - IsNotDevEnvironment
+        - !Ref LambdaConcurrency
+        - !Ref AWS::NoValue
       CodeUri: ../src/
       Environment:
         Variables:
@@ -669,6 +686,10 @@ Resources:
       FunctionName: !Sub "Access-Token-${AWS::StackName}"
       Handler: AccessTokenHandler.lambdaHandler
       CodeUri: ../src/
+      ReservedConcurrentExecutions: !If
+        - IsNotDevEnvironment
+        - !Ref LambdaConcurrency
+        - !Ref AWS::NoValue
       Environment:
         Variables:
           POWERTOOLS_SERVICE_NAME: AccessTokenHandler
@@ -745,6 +766,10 @@ Resources:
       FunctionName: !Sub "CIC-Authorization-${AWS::StackName}"
       Handler: AuthorizationCodeHandler.lambdaHandler
       CodeUri: ../src/
+      ReservedConcurrentExecutions: !If
+        - IsNotDevEnvironment
+        - !Ref LambdaConcurrency
+        - !Ref AWS::NoValue
       Environment:
         Variables:
           POWERTOOLS_SERVICE_NAME: AuthorizationCodeHandler
@@ -916,8 +941,8 @@ Resources:
       CodeUri: ../src/
       Handler: JwksHandler.lambdaHandler
       ReservedConcurrentExecutions: !If
-        - IsProdLikeEnvironment
-        - 80
+        - IsNotDevEnvironment
+        - !Ref LambdaConcurrency
         - !Ref AWS::NoValue
       Policies:
         - AWSXRayDaemonWriteAccess

--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -55,9 +55,13 @@ Parameters:
     Type: String
     Default: 'https://govukverify.atlassian.net/wiki/spaces/FTFCRI/pages/3602251909/CIC+Support+Documentation'
   LambdaConcurrency:
-    Description: "Reserved concurrency for Lambdas running in non-dev environments"
+    Description: "Reserved concurrency for Lambdas running in non-DEV environments"
     Type: Number
     Default: 20
+  ApplyReservedConcurrencyInDev:
+    Description: "Set to true to apply reserved concurrency when deploying in DEV environments"
+    Type: String
+    Default: "false"
 
 Mappings:
   EnvironmentConfiguration: # This is where you store per-environment settings.
@@ -147,8 +151,10 @@ Conditions:
   CreateDevResources: !Equals
     - !Ref Environment
     - dev
-  IsNotDevEnvironment: !Not
-    - !Condition CreateDevResources
+  ApplyReservedConcurrency: !Or
+    - !Not
+      - !Condition CreateDevResources
+    - !Equals [!Ref ApplyReservedConcurrencyInDev, "true"]
   IsProdLikeEnvironment: !Or
     - !Equals [!Ref Environment, staging]
     - !Equals [!Ref Environment, integration]
@@ -396,7 +402,7 @@ Resources:
       Handler: ClaimedIdentityHandler.lambdaHandler
       CodeUri: ../src/
       ReservedConcurrentExecutions: !If
-        - IsNotDevEnvironment
+        - ApplyReservedConcurrency
         - !Ref LambdaConcurrency
         - !Ref AWS::NoValue
       Environment:
@@ -478,7 +484,7 @@ Resources:
       Handler: UserInfoHandler.lambdaHandler
       CodeUri: ../src/
       ReservedConcurrentExecutions: !If
-        - IsNotDevEnvironment
+        - ApplyReservedConcurrency
         - !Ref LambdaConcurrency
         - !Ref AWS::NoValue
       Environment:
@@ -579,7 +585,7 @@ Resources:
       FunctionName: !Sub "CIC-Session-${AWS::StackName}"
       Handler: SessionHandler.lambdaHandler
       ReservedConcurrentExecutions: !If
-        - IsNotDevEnvironment
+        - ApplyReservedConcurrency
         - !Ref LambdaConcurrency
         - !Ref AWS::NoValue
       CodeUri: ../src/
@@ -687,7 +693,7 @@ Resources:
       Handler: AccessTokenHandler.lambdaHandler
       CodeUri: ../src/
       ReservedConcurrentExecutions: !If
-        - IsNotDevEnvironment
+        - ApplyReservedConcurrency
         - !Ref LambdaConcurrency
         - !Ref AWS::NoValue
       Environment:
@@ -767,7 +773,7 @@ Resources:
       Handler: AuthorizationCodeHandler.lambdaHandler
       CodeUri: ../src/
       ReservedConcurrentExecutions: !If
-        - IsNotDevEnvironment
+        - ApplyReservedConcurrency
         - !Ref LambdaConcurrency
         - !Ref AWS::NoValue
       Environment:
@@ -941,7 +947,7 @@ Resources:
       CodeUri: ../src/
       Handler: JwksHandler.lambdaHandler
       ReservedConcurrentExecutions: !If
-        - IsNotDevEnvironment
+        - ApplyReservedConcurrency
         - !Ref LambdaConcurrency
         - !Ref AWS::NoValue
       Policies:


### PR DESCRIPTION

![Screenshot 2023-08-02 at 18 52 41](https://github.com/alphagov/di-ipv-cri-cic-api/assets/131283983/30725bca-3963-4d68-934f-f4520e85edcd)
![Screenshot 2023-08-02 at 18 57 07](https://github.com/alphagov/di-ipv-cri-cic-api/assets/131283983/0265e245-bfb2-4cbd-ad12-d706c5ee5d4f)
## Proposed changes

### What changed

Set reserved concurrencies for all lambdas which are deployed in all non-DEV environments. These are required in BUILD since this is the environment used in performance testing. A parameter has been added to allow them to be set when manually deploying in DEV should this be needed, but this must not be default.

### Why did it change

Per requirements on ticket

### Issue tracking

- [F2F-779](https://govukverify.atlassian.net/browse/F2F-779)

## Checklists

### PII logging

- [X] Verified that no PII data is being logged

### Environment variables or secrets

- [X] No environment variables or secrets were added or changed

### Other considerations

- [X] Update [README](./blob/main/README.md) with any new instructions or tasks


[F2F-779]: https://govukverify.atlassian.net/browse/F2F-779?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ