### PR TITLE
[F2F-672] Creates new GlobalSecondaryIndexes for expired session check

### DIFF
--- a/infra-l2-dynamo/template.yaml
+++ b/infra-l2-dynamo/template.yaml
@@ -84,7 +84,6 @@ Resources:
               - "redirectUri"
               - "clientId"
               - "authSessionState"
-              - "expiryDate"
             ProjectionType: "INCLUDE"
         - IndexName: "authCode-index"
           KeySchema:
@@ -97,6 +96,19 @@ Resources:
               - "clientId"
               - "authSessionState"
               - "clientSessionId"
+            ProjectionType: "INCLUDE"
+        - IndexName: "authCode-updated-index"
+          KeySchema:
+            - AttributeName: "authorizationCode"
+              KeyType: "HASH"
+          Projection:
+            NonKeyAttributes:
+              - "sessionId"
+              - "redirectUri"
+              - "clientId"
+              - "authSessionState"
+              - "clientSessionId"
+              - "expiryDate"
             ProjectionType: "INCLUDE"
       TimeToLiveSpecification:
         AttributeName: expiryDate

--- a/infra-l2-dynamo/template.yaml
+++ b/infra-l2-dynamo/template.yaml
@@ -84,6 +84,7 @@ Resources:
               - "redirectUri"
               - "clientId"
               - "authSessionState"
+              - "expiryDate"
             ProjectionType: "INCLUDE"
         - IndexName: "authCode-index"
           KeySchema:

--- a/src/services/AccessTokenRequestProcessor.ts
+++ b/src/services/AccessTokenRequestProcessor.ts
@@ -71,6 +71,10 @@ export class AccessTokenRequestProcessor {
     				messageCode: MessageCodes.SESSION_NOT_FOUND,
     				error,
     			});
+
+    			if (error instanceof AppError) {
+    				return new Response(error.statusCode, error.message);
+    			}
     			return new Response(HttpCodesEnum.UNAUTHORIZED, "Error while retrieving the session");
     		}
 

--- a/src/utils/Constants.ts
+++ b/src/utils/Constants.ts
@@ -44,7 +44,7 @@ export class Constants {
 
     static readonly AUTHORIZATION_CODE = "authorization_code";
 
-    static readonly AUTHORIZATION_CODE_INDEX_NAME = "authCode-index";
+    static readonly AUTHORIZATION_CODE_INDEX_NAME = "authCode-updated-index";
 
     static readonly TOKEN_EXPIRY_SECONDS = 3600;
 

--- a/test-harness/test-harness-spec.yaml
+++ b/test-harness/test-harness-spec.yaml
@@ -133,7 +133,7 @@ paths:
           application/json: |
             {
               "TableName":"$input.params('tableName')",
-              "IndexName":"authorizationCode-index",
+              "IndexName":"authCode-updated-index",
               "KeyConditionExpression": "authorizationCode = :authorizationCode",
               "ExpressionAttributeValues":{
                   ":authorizationCode":{


### PR DESCRIPTION
## Proposed changes

### What changed

Addes expiryDate to `GlobalSecondaryIndexes` so that it is returned when session table is queried using `authorizationCode-index`

### Why did it change

Because the returned record did not include `expiryDate` and therefore the expired check wasn't working

### Screenshots
![Screenshot 2023-07-25 at 1 40 43 pm](https://github.com/alphagov/di-ipv-cri-cic-api/assets/40401118/a20cfd2e-71db-457a-80fd-954f2f44df30)

![Screenshot 2023-07-25 at 1 39 40 pm](https://github.com/alphagov/di-ipv-cri-cic-api/assets/40401118/4d99e51c-2532-465a-a63e-b1c9cfb49b14)

No regression on sign in ID
<img width="761" alt="image" src="https://github.com/alphagov/di-ipv-cri-cic-api/assets/40401118/420b8337-e6f6-4ab3-bec3-2a29ca9ca59e">



### Issue tracking
- [F2F-672](https://govukverify.atlassian.net/browse/F2F-672)

## Checklists

### PII logging

- [x] Verified that no PII data is being logged


[F2F-672]: https://govukverify.atlassian.net/browse/F2F-672?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ