### PR TITLE
Forcing test harness apigw redeploy

### DIFF
--- a/test-harness/template.yaml
+++ b/test-harness/template.yaml
@@ -281,6 +281,7 @@ Resources:
   TestHarnessRestApi:
     Type: AWS::Serverless::Api
     Properties:
+      AlwaysDeploy: true
       StageName: !Ref Environment
       OpenApiVersion: 3.0.1
       AccessLogSetting:


### PR DESCRIPTION
## Proposed changes

### What changed

Set `AlwaysDeploy: true` for test harness api gateway definition

### Why did it change

To redeploy even if changes aren't detected (api gateway is currently using the wrong role)

