### PR TITLE
F2F-1135 Update TESTHARNESS in BUILD main template

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -111,7 +111,7 @@ Mappings:
       CLIENTS: '[{"jwksEndpoint":"https://ipvstub.review-c.build.account.gov.uk/.well-known/jwks.json","clientId":"BD7B2A5D","redirectUri":"https://ipvstub.review-c.build.account.gov.uk/redirect"}]'
       TXMAMESSAGERETENTIONPERIODDAYS: 604800 # Default: 7 days
       AUTHSESSIONTTL: "950400" # 11 days in seconds
-      TESTHARNESSURL: "https://cic-test-harness-testharness.review-c.build.account.gov.uk"
+      TESTHARNESSURL: "https://testharness.review-c.build.account.gov.uk"
     staging:
       ISSUER: "https://review-c.staging.account.gov.uk"
       DNSSUFFIX: review-c.staging.account.gov.uk


### PR DESCRIPTION
## Proposed changes

### What changed

TESTHARNESS definition in build main template

### Why did it change

was previously incorrect causing the test-container in build to fail and the pipeline to be blocked

### Issue tracking

- [F2F-1135](https://govukverify.atlassian.net/browse/F2F-1135)

## Checklists

### PII logging

- [X] Verified that no PII data is being logged

### Environment variables or secrets

- [X] No environment variables or secrets were added or changed

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks


[F2F-1135]: https://govukverify.atlassian.net/browse/F2F-1135?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ