### PR TITLE
[F2F[1098] Removing the unused authorizationCode-index index and its references.

### DIFF
--- a/infra-l2-dynamo/template.yaml
+++ b/infra-l2-dynamo/template.yaml
@@ -74,17 +74,6 @@ Resources:
         - AttributeName: "sessionId"
           KeyType: "HASH"
       GlobalSecondaryIndexes:
-        - IndexName: "authorizationCode-index"
-          KeySchema:
-            - AttributeName: "authorizationCode"
-              KeyType: "HASH"
-          Projection:
-            NonKeyAttributes:
-              - "sessionId"
-              - "redirectUri"
-              - "clientId"
-              - "authSessionState"
-            ProjectionType: "INCLUDE"
         - IndexName: "authCode-index"
           KeySchema:
             - AttributeName: "authorizationCode"

--- a/test-harness/test-harness-spec.yaml
+++ b/test-harness/test-harness-spec.yaml
@@ -87,7 +87,7 @@ paths:
   getSessionByAuthCode/{tableName}/{authCode}:
     get:
       operationId: getSessionByAuthCode
-      summary: Get a session by using authorizationCode-index from DynamoDB
+      summary: Get a session by using authCode-index from DynamoDB
       description: |
         Endpoint to get a session from DynamoDB using either authCode as the primary key
       parameters:
@@ -133,7 +133,7 @@ paths:
           application/json: |
             {
               "TableName":"$input.params('tableName')",
-              "IndexName":"authorizationCode-index",
+              "IndexName":"authCode-index",
               "KeyConditionExpression": "authorizationCode = :authorizationCode",
               "ExpressionAttributeValues":{
                   ":authorizationCode":{


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[F2F-XXX] PR Title` -->

## Proposed changes

### What changed

Removing the unused authorizationCode-index index and its references as a new index authCode-index was introduced as part of F2F-1080

### Why did it change

authCode-index was added and deployed in prod which is working as expected and the old index is ununsed and needs to be removed.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [F2F-1098](https://govukverify.atlassian.net/browse/F2F-1098)

## Checklists

### PII logging

- [x] Verified that no PII data is being logged

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->
- [x] No environment variables or secrets were added or changed



[F2F-1098]: https://govukverify.atlassian.net/browse/F2F-1098?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ