### PR TITLE
[KIWI-1137] Remove Unused authCode-index

### DIFF
--- a/infra-l2-dynamo/template.yaml
+++ b/infra-l2-dynamo/template.yaml
@@ -74,18 +74,6 @@ Resources:
         - AttributeName: "sessionId"
           KeyType: "HASH"
       GlobalSecondaryIndexes:
-        - IndexName: "authCode-index"
-          KeySchema:
-            - AttributeName: "authorizationCode"
-              KeyType: "HASH"
-          Projection:
-            NonKeyAttributes:
-              - "sessionId"
-              - "redirectUri"
-              - "clientId"
-              - "authSessionState"
-              - "clientSessionId"
-            ProjectionType: "INCLUDE"
         - IndexName: "authCode-updated-index"
           KeySchema:
             - AttributeName: "authorizationCode"


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[F2F-XXX] PR Title` -->

## Proposed changes

### What changed

Removing Unused authCode-index

### Why did it change

Tech debt

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [KIWI-1137](https://govukverify.atlassian.net/browse/KIWI-1137)

Evidences:
Before indexes:
<img width="716" alt="Screenshot 2023-09-25 at 12 35 44" src="https://github.com/alphagov/di-ipv-cri-cic-api/assets/115095929/6ca5eb71-561f-4d5c-ab53-998225247518">

After index list:
<img width="596" alt="Screenshot 2023-09-25 at 12 35 55" src="https://github.com/alphagov/di-ipv-cri-cic-api/assets/115095929/2499a7aa-cbb5-42fa-b35c-d602f7355276">



[KIWI-1137]: https://govukverify.atlassian.net/browse/KIWI-1137?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ