### PR TITLE
[KIWI-1299] Replaces deprecated script in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,13 @@ FROM ubuntu:latest
 RUN apt update -y && apt upgrade -y
 RUN apt install -y curl unzip
 
-RUN curl -sL https://deb.nodesource.com/setup_18.x | bash -
-RUN apt install -y nodejs
+RUN apt-get install -y ca-certificates curl gnupg
+RUN mkdir -p /etc/apt/keyrings
+RUN curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg
+ENV NODE_MAJOR=18
+RUN echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_$NODE_MAJOR.x nodistro main" | tee /etc/apt/sources.list.d/nodesource.list
+RUN apt-get update
+RUN apt-get install nodejs -y
 
 RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
 RUN unzip awscliv2.zip


### PR DESCRIPTION
## Proposed changes

### What changed

Replaces deprecated script in Dockerfile

### Why did it change

To save time in our local runs

### Issue tracking

- [F2F-1299](https://govukverify.atlassian.net/browse/F2F-1299)

### Screenshots

No issues when running `run-tests-locally`
<img width="1136" alt="Screenshot 2023-10-11 at 4 20 16 pm" src="https://github.com/alphagov/di-ipv-cri-cic-api/assets/40401118/37cac665-ba28-47d1-831a-9b2f4cb44d7f">
