### PR TITLE
[KIWI-2370] - CIC | OAuth | Move public encryption keys to new S3

### DIFF
--- a/deploy/cic-spec.yaml
+++ b/deploy/cic-spec.yaml
@@ -575,7 +575,7 @@ paths:
         credentials:
           Fn::GetAtt: [ "JWKSBucketRole", "Arn" ]
         uri:
-          Fn::Sub: "arn:aws:apigateway:${AWS::Region}:s3:path/govuk-one-login-cic-published-keys-${Environment}/.well-known/jwks.json"
+          Fn::Sub: "arn:aws:apigateway:${AWS::Region}:s3:path/govuk-one-login-cic-published-keys-${Environment}/jwks.json"
         responses:
           default:
             statusCode: "200"


### PR DESCRIPTION
### What changed

Followup PR to update /.well-known e/p S3 intagration to use new "published-keys" bucket from the common-infra stack
Removal of test endpoint added to APIGW to confirm contents of bucket in production environment

### Why did it change

To ensure the /.well-known e/p points to the correct bucket for key rotation, following successful update and execution of the JWKS lambda (which publishes existing keys to the new "published-keys" bucket)

### Issue tracking

- [KIWI-2370](https://govukverify.atlassian.net/browse/KIWI-2370)

### Evidence

<img width="1597" alt="image" src="https://github.com/user-attachments/assets/e834de81-7865-41e1-a9db-7a24406041bc" />


[KIWI-2306]: https://govukverify.atlassian.net/browse/KIWI-2306?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[KIWI-2370]: https://govukverify.atlassian.net/browse/KIWI-2370
<img width="1847" height="1158" alt="Screenshot 2025-07-21 at 19 40 07" src="https://github.com/user-attachments/assets/60d0808c-e5af-46fc-94ab-553bbce216e0" />
?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ