### PR TITLE
[KIWI-2476] - CIC | Add FMS tags for custom WAF policy migration in lower environments

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -611,8 +611,8 @@ Resources:
         Service: backend
         Name: CICRestApi
         Source: alphagov/di-devplatform-demo-sam-app/sam-app/template.yaml
-        FMSRegionalPolicy: false
-        CustomPolicy: true
+        FMSRegionalPolicy: !If [IsPersonalIdentifiableInformationEnvironment, !Ref "AWS::NoValue", "false"]
+        CustomPolicy: !If [IsPersonalIdentifiableInformationEnvironment, !Ref "AWS::NoValue", "true"]
 
   CICAPIGatewayAccessLogGroup:
     Type: AWS::Logs::LogGroup
@@ -703,6 +703,11 @@ Resources:
           - REGIONAL
       RegionalCertificateArn: !Sub "{{resolve:ssm:/${Environment}/Platform/ACM/PrimaryZoneWildcardCertificateARN}}"
       SecurityPolicy: TLS_1_2
+      Tags:
+        - Key: FMSRegionalPolicy
+          Value: !If [IsPersonalIdentifiableInformationEnvironment, !Ref "AWS::NoValue", "false"]
+        - Key: CustomPolicy
+          Value: !If [IsPersonalIdentifiableInformationEnvironment, !Ref "AWS::NoValue", "true"]
 
   CICApiCertificateRecord:
     Type: AWS::Route53::RecordSet


### PR DESCRIPTION
### What changed

Added Firewall Manager (FMS) tags to template file

### Why did it change

To accommodate a transition from COUNT (logging rule violations) to BLOCK (actively blocking rule violations) in the lower environments

### Issue tracking
- [KIWI-2476](https://govukverify.atlassian.net/browse/KIWI-2476)

#### Tags in Custom domain names

<img width="715" height="295" alt="Screenshot 2025-10-01 at 17 00 03" src="https://github.com/user-attachments/assets/f0bb7fed-b789-45e6-960a-14c9d59703b7" />

#### Tags in Stages

<img width="688" height="483" alt="Screenshot 2025-10-01 at 16 59 11" src="https://github.com/user-attachments/assets/a4a68471-c72e-4de0-93b2-aa464c9525e3" />

[KIWI-2476]: https://govukverify.atlassian.net/browse/KIWI-2476?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ