### PR TITLE
[KIWI-2897] -| BE | Update Dynatrace environment variables to migrate from classic to latest lambda configuration

### DIFF
--- a/deploy/template.yaml
+++ b/deploy/template.yaml
@@ -268,7 +268,7 @@ Globals:
         DT_CONNECTION_BASE_URL: !Sub
           - '{{resolve:secretsmanager:${SecretArn}:SecretString:DT_CONNECTION_BASE_URL}}' #pragma: allowlist secret
           - SecretArn: !FindInMap [ EnvironmentConfiguration, !Ref Environment, dynatraceSecretArn ]
-        DT_CLUSTER_ID: !Sub
+        DT_CLUSTER: !Sub
           - '{{resolve:secretsmanager:${SecretArn}:SecretString:DT_CLUSTER_ID}}' #pragma: allowlist secret
           - SecretArn: !FindInMap [ EnvironmentConfiguration, !Ref Environment, dynatraceSecretArn ]
         DT_LOG_COLLECTION_AUTH_TOKEN: !Sub
@@ -277,7 +277,6 @@ Globals:
         DT_TENANT: !Sub
           - '{{resolve:secretsmanager:${SecretArn}:SecretString:DT_TENANT}}' #pragma: allowlist secret
           - SecretArn: !FindInMap [ EnvironmentConfiguration, !Ref Environment, dynatraceSecretArn ]
-        DT_OPEN_TELEMETRY_ENABLE_INTEGRATION: "true"
         # These should always be alphabetically organised.
         AWS_STACK_NAME: !Sub ${AWS::StackName} # The AWS Stack Name, as passed into the template.
         POWERTOOLS_LOG_LEVEL: !Ref PowertoolsLogLevel # The LogLevel for the AWS PowerTools LogHelper


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[KIWI-XXXX] PR Title` -->

## Proposed changes

### What changed

<!-- Describe the changes in detail - the "what"-->
Env vars changed:
- DT_CLUSTER_ID -> DT_CLUSTER
- DT_OPEN_TELEMETRY_ENABLE_INTEGRATION removed

### Why did it change

<!-- Describe the reason these changes were made - the "why" -->
To migrate from classic to latest lambda configuration

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [KIWI-2897](https://govukverify.atlassian.net/browse/KIWI-2897)

Non prod dashboard tracing functional post env var change

<img width="1503" height="750" alt="Screenshot 2026-08-21 at 16 11 29" src="https://github.com/user-attachments/assets/5bc3c9b4-f040-4078-a73d-899b2bba276b" />


[KIWI-2897]: https://govukverify.atlassian.net/browse/KIWI-2897?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ